### PR TITLE
Bypass confirmation token while downloading model

### DIFF
--- a/tts_websocketserver/src/tts_websocketserver/initialize.py
+++ b/tts_websocketserver/src/tts_websocketserver/initialize.py
@@ -30,9 +30,8 @@ def download_file_from_google_drive(id, destination):
     response = session.get(URL, params = { 'id' : id }, stream = True)
     token = get_confirm_token(response)
 
-    if token:
-        params = { 'id' : id, 'confirm' : token }
-        response = session.get(URL, params = params, stream = True)
+    params = { 'id' : id, 'confirm' : 1 }
+    response = session.get(URL, params = params, stream = True)
 
     save_response_content(response, destination) 
 


### PR DESCRIPTION
Set confirm parameter to 1 explicitly and remove the if statement in order to download the model from Google Drive, previously causing error possibly due to some unknown internal changes within Google Drive